### PR TITLE
Added public image location in Header.js

### DIFF
--- a/frontend/src/components/Header.js
+++ b/frontend/src/components/Header.js
@@ -42,7 +42,8 @@ const LoggedInView = (props) => {
         <li className="nav-item">
           <Link to={`/@${props.currentUser.username}`} className="nav-link">
             <img
-              src={props.currentUser.image}
+              // src={props.currentUser.image}
+              src = "placeholder.png"
               className="user-pic pr-1"
               alt={props.currentUser.username}
             />


### PR DESCRIPTION
# Description

Added public image "placeholder.png" in header.js to resolve the broken image issue.
Please see attached screenshot as an evidence of issue resolution as there is no more broken image displaying now.
![image](https://user-images.githubusercontent.com/43045514/182701054-13393b9c-8018-40d8-b0ab-6caab0f84c38.png)

